### PR TITLE
Fixed personalization

### DIFF
--- a/recmetrics/metrics.py
+++ b/recmetrics/metrics.py
@@ -139,7 +139,7 @@ def personalization(predicted):
             id_vars='index', value_name='item',
         )
         df = df[['index', 'item']].pivot(index='index', columns='item', values='item')
-        df = df.mask(pd.notna(df), 1)
+        df = pd.notna(df)*1
         rec_matrix = sp.csr_matrix(df.values)
         return rec_matrix
 


### PR DESCRIPTION
Personalization gave the following error with the example input.

` File "recmetrics/metrics.py", line 149, in personalization
    rec_matrix_sparse = make_rec_matrix(predicted)
  File "recmetrics/metrics.py", line 144, in make_rec_matrix
    rec_matrix = sp.csr_matrix(df.values)
  File "/usr/local/lib/python3.7/site-packages/scipy/sparse/compressed.py", line 88, in __init__
    self._set_self(self.__class__(coo_matrix(arg1, dtype=dtype)))
  File "/usr/local/lib/python3.7/site-packages/scipy/sparse/compressed.py", line 37, in __init__
    arg1 = arg1.asformat(self.format)
  File "/usr/local/lib/python3.7/site-packages/scipy/sparse/base.py", line 328, in asformat
    return convert_method()
  File "/usr/local/lib/python3.7/site-packages/scipy/sparse/coo.py", line 406, in tocsr
    data = np.empty_like(self.data, dtype=upcast(self.dtype))
  File "/usr/local/lib/python3.7/site-packages/scipy/sparse/sputils.py", line 52, in upcast
    raise TypeError('no supported conversion for types: %r' % (args,))
TypeError: no supported conversion for types: (dtype('O'),)`