### PR TITLE
fix setup requires error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'seaborn',
         'surprise',
         'funcsigs',
+        'plotly'
     ],
     license='MIT',
     version='0.0.12',


### PR DESCRIPTION
add plotly in setup.py as install_requires

- error

```sh
pip3 install git+https://github.com/statisticianinstilettos/recmetrics.git
```

```sh
python3
>>> import recmetrics
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/uni/Library/Python/3.7/lib/python/site-packages/recmetrics/__init__.py", line 1, in <module>
    from .plots import long_tail_plot, mark_plot, mapk_plot, coverage_plot, class_separation_plot, roc_plot, precision_recall_plot
  File "/Users/uni/Library/Python/3.7/lib/python/site-packages/recmetrics/plots.py", line 7, in <module>
    import plotly.graph_objects as go
ModuleNotFoundError: No module named 'plotly'
```